### PR TITLE
Change type of some columns of table video_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 4.0.5
+- Fix bug that old video_file cannot be removed.
+
 ## 4.0.4
 - Remove uid and user config from Dockerfile to avoid conflict
 

--- a/service/admin.py
+++ b/service/admin.py
@@ -634,7 +634,11 @@ class AdminService:
                 except Exception as error:
                     logger.warn(error)
 
-            requests.delete(self.download_manager_url + '/file/torrent/' + video_file.task_id)
+            try:
+                requests.delete(self.download_manager_url + '/file/torrent/' + video_file.task_id)
+            except Exception as error:
+                logger.warn(error)
+
             session.delete(video_file)
 
             session.commit()


### PR DESCRIPTION
Fix bug that old video_files which using deluge as a downloader cannot be removed.