### PR TITLE
Add watch_progress.id to the response of update history API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.3.0
+Add watch_progress.id to the response of update history(/watch/history/<episode_id>) API
+
 ## 4.2.4
 Use magnet_uri for all modes to workaround with bangumi.moe torrent download issue.
 

--- a/service/watch.py
+++ b/service/watch.py
@@ -129,7 +129,7 @@ class WatchService:
                 watch_progress.percentage = percentage
                 session.commit()
 
-            return json_resp({'message': 'ok', 'status': 0})
+            return json_resp({'message': 'ok', 'data': str(watch_progress.id), 'status': 0})
         finally:
             SessionManager.Session.remove()
 


### PR DESCRIPTION
Add the `data` field in the update/add history API, its value is the WatchProgress.id