### PR TITLE
Feat/s3 and bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 5.2.0
+Change how the backend will convert S3 URI to http URL to support new backend.
+Fix a bug that causing the backend cannot save watch progress from synchronize_history api.
 
 ## 5.1.0
 Set watch_progress.percent to 1 when watch_status is WATCHED and percentage is None

--- a/config/config-sample.yml
+++ b/config/config-sample.yml
@@ -84,9 +84,16 @@ universal:
 download_manager_url: 'http://localhost:8081'
 video_manager_url: 'http://localhost:8083'
 
-s3_to_http_url_template: 'http://localhost:8334/${bucket}/${key}'
-
 migration:
   JWT_ISSUER: 'albireo'
   JWT_AUDIENCE: 'mira-migration'
   JWT_SECRET: 'CHANGE-TO-A-VERY-LONG-SECRET'
+
+# The config for access S3 bucket and convert the S3 URI in the VideoFile to http url.
+s3_public_config:
+  video_bucket: 'public-video'
+  image_bucket: 'public-image'
+  # the HttpURLPattern should have {bucket} and {key} as placeholder to be replaced by the S3 bucket and key.
+  video_http_url_pattern: 'http://localhost:8333/{bucket}/{key}'
+  image_http_url_pattern: 'http://localhost:8333/{bucket}/{key}'
+  fallback_url_pattern: 'http://localhost:8333/{bucket}/{key}'

--- a/service/watch.py
+++ b/service/watch.py
@@ -184,13 +184,18 @@ class WatchService:
                 filter(WatchProgress.episode_id.in_(episode_id_list)).\
                 all()
 
+            # episode ids come from the client as strings while the ORM maps them to uuid.UUID,
+            # so always key the lookup tables by the lower cased string form to make both sides comparable.
+            episode_dict = dict((str(episode.id).lower(), episode) for episode in episode_list)
+
             # remove duplicate records, records can be duplicate when client send records concurrently
             eps_id_dict = {}
             for watch_progress in watch_progress_list:
-                episode_id = str(watch_progress.episode_id)
+                episode_id = str(watch_progress.episode_id).lower()
                 if episode_id in eps_id_dict:
-                    if eps_id_dict[episode_id].last_watch_time < watch_progress.last_watch_time:
-                        session.delete(eps_id_dict[episode_id])
+                    kept = eps_id_dict[episode_id]
+                    if (kept.last_watch_time or datetime.min) < (watch_progress.last_watch_time or datetime.min):
+                        session.delete(kept)
                         eps_id_dict[episode_id] = watch_progress
                     else:
                         session.delete(watch_progress)
@@ -200,22 +205,21 @@ class WatchService:
             # synchronize
             for record in records:
                 watch_status = WatchProgress.WATCHED if record.get('is_finished') else WatchProgress.WATCHING
-                last_watch_time = datetime.utcfromtimestamp(record['last_watch_time'] / 1000)
-                record_found = False
-                for watch_progress in watch_progress_list:
-                    if str(watch_progress.episode_id) == record['episode_id']:
-                        record_found = True
-                        if watch_progress.last_watch_time <= last_watch_time:
-                            # Once watch status is Watch. we should not change it to other status
-                            if watch_progress.watch_status is not WatchProgress.WATCHED:
-                                watch_progress.watch_status = watch_status
-                            watch_progress.last_watch_time = last_watch_time
-                            watch_progress.last_watch_position = record['last_watch_position']
-                            watch_progress.percentage = record['percentage']
-                        break
-                if not record_found:
-                    episode = next((eps for eps in episode_list if eps.id == record['episode_id']), None)
+                last_watch_time = datetime.utcfromtimestamp(record['last_watch_time'] / 1000.0)
+                episode_id = record['episode_id'].lower()
+                watch_progress = eps_id_dict.get(episode_id)
+                if watch_progress is not None:
+                    if (watch_progress.last_watch_time or datetime.min) <= last_watch_time:
+                        # Once watch status is Watch. we should not change it to other status
+                        if watch_progress.watch_status != WatchProgress.WATCHED:
+                            watch_progress.watch_status = watch_status
+                        watch_progress.last_watch_time = last_watch_time
+                        watch_progress.last_watch_position = record['last_watch_position']
+                        watch_progress.percentage = record['percentage']
+                else:
+                    episode = episode_dict.get(episode_id)
                     if not episode:
+                        logger.warn('Skipped watch history record of unknown episode %s', episode_id)
                         continue
                     watch_progress = WatchProgress(bangumi_id=record['bangumi_id'],
                                                    episode_id=record['episode_id'],
@@ -226,10 +230,12 @@ class WatchService:
                                                    percentage=record['percentage'],
                                                    subItemId=episode.sub_item_id)
                     session.add(watch_progress)
+                    eps_id_dict[episode_id] = watch_progress
             session.commit()
             return json_resp({'message': 'ok', 'status': 0})
-        except Exception as error:
-            logger.warn(traceback.format_exc(error))
+        except Exception:
+            session.rollback()
+            logger.warn(traceback.format_exc())
             # always return success even operation failed
             return json_resp({'message': 'ok', 'status': 0})
         finally:

--- a/utils/common.py
+++ b/utils/common.py
@@ -25,10 +25,15 @@ class CommonUtils:
         self.base_path = config['download']['location']
         self.image_domain = config['domain']['image']
         self.video_domain = config['domain']['video']
-        if 's3_to_http_url_template' in config:
-            self.s3_to_http_url_template = Template(config['s3_to_http_url_template'])
-        else:
-            self.s3_to_http_url_template = None
+        self.s3_mode = False
+        if 's3_public_config' in config:
+            self.video_http_url_template = Template(config['s3_public_config']['video_http_url_template'])
+            self.image_http_url_template = Template(config['s3_public_config']['image_http_url_template'])
+            self.fallback_url_template = Template(config['s3_public_config']['fallback_url_template'])
+            self.video_bucket = config['s3_public_config']['video_bucket']
+            self.image_bucket = config['s3_public_config']['image_bucket']
+            self.s3_mode = True
+
         try:
             if not os.path.exists(self.base_path):
                 os.makedirs(self.base_path)
@@ -105,14 +110,19 @@ class CommonUtils:
         return dict.get(attr_name, None) if dict.get(attr_name, None) else None
 
     def convert_s3_to_http_url(self, s3_path):
-        if self.s3_to_http_url_template is None:
+        if not self.s3_mode:
             return None
-        search_result = re.search('^s3://([\w.\-]+)/([\w.\-]+)', s3_path, re.U | re.I)
+        search_result = re.search('^s3://([^/]+)/([^/]+)', s3_path, re.U | re.I)
         if search_result is None:
             return None
         bucket = search_result.group(1)
         key = search_result.group(2)
-        return self.s3_to_http_url_template.safe_substitute(bucket=bucket, key=key)
+        if bucket == self.image_bucket:
+            return self.image_http_url_template.safe_substitute(bucket=bucket, key=key)
+        elif bucket == self.video_bucket:
+            return self.video_http_url_template.safe_substitute(bucket=bucket, key=key)
+        else:
+            return self.fallback_url_template.safe_substitute(bucket=bucket, key=key)
 
 
 utils = CommonUtils()


### PR DESCRIPTION
This pull request introduces improvements to S3 URL handling and fixes a bug in the watch history synchronization process. The main changes include updating S3 URL conversion to support a new backend, enhancing configuration for S3 public access, and resolving issues with duplicate and unsaved watch progress records.

**S3 URL handling improvements:**

* Added a new `s3_public_config` section in `config/config-sample.yml` to specify S3 buckets and HTTP URL patterns for video and image resources, replacing the previous `s3_to_http_url_template` approach. (`config/config-sample.yml`, [config/config-sample.ymlL87-R99](diffhunk://#diff-2b802567a82762cf302e8f07f8fab79d972e17204ad2f8687804a43b879d3c8cL87-R99))
* Refactored the `CommonUtils` class to use the new S3 public config, supporting bucket-specific HTTP URL templates and a fallback template. The S3 to HTTP URL conversion now distinguishes between image, video, and other buckets. (`utils/common.py`, [[1]](diffhunk://#diff-03a067a667a3d2ac3e641e76437319edbdf67b06087a5867c1dcdb16283d8265L28-R36) [[2]](diffhunk://#diff-03a067a667a3d2ac3e641e76437319edbdf67b06087a5867c1dcdb16283d8265L108-R125)

**Watch history synchronization bugfixes:**

* Fixed a bug in `synchronize_history` where episode IDs were inconsistently compared as strings and UUIDs, causing records to not be properly matched or updated. Now, all episode IDs are compared as lower-cased strings. (`service/watch.py`, [[1]](diffhunk://#diff-7db2500285c55858692c0bffbbb80c7ea4b29580f4d59b10f4a7c0e901dc4504R187-R198) [[2]](diffhunk://#diff-7db2500285c55858692c0bffbbb80c7ea4b29580f4d59b10f4a7c0e901dc4504L203-R222)
* Improved duplicate record handling and ensured that new or updated watch progress entries are properly tracked and committed. (`service/watch.py`, [[1]](diffhunk://#diff-7db2500285c55858692c0bffbbb80c7ea4b29580f4d59b10f4a7c0e901dc4504R187-R198) [[2]](diffhunk://#diff-7db2500285c55858692c0bffbbb80c7ea4b29580f4d59b10f4a7c0e901dc4504R233-R238)
* Added rollback on exceptions during synchronization to prevent partial commits, and improved logging for unknown episodes and errors. (`service/watch.py`, [service/watch.pyR233-R238](diffhunk://#diff-7db2500285c55858692c0bffbbb80c7ea4b29580f4d59b10f4a7c0e901dc4504R233-R238))

**Documentation:**

* Updated `CHANGELOG.md` to document the S3 URL handling change and the watch progress bugfix. (`CHANGELOG.md`, [CHANGELOG.mdR2-R4](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR2-R4))